### PR TITLE
Adiciona description e plain language aos schemas do repositório

### DIFF
--- a/schemas/acoes_planejamento.yaml
+++ b/schemas/acoes_planejamento.yaml
@@ -62,7 +62,7 @@ fields:
         - 7
         - 8
         - 9
-    description: >
+    detailed_description: >
       As ações classificam-se nos seguintes tipos:
 
       a) Projeto: é instrumento de programação orientado para alcançar o objetivo de um programa. 
@@ -116,6 +116,8 @@ fields:
       materiais, 
       institucionais, 
       etc.
+    description: Instrumento de programação para alcançar o objetivo de um programa, sendo a unidade básica de planejamento e execução orçamentária. Classifica-se em: Projeto (operações limitadas no tempo que expandem a ação de governo), Atividade (operações contínuas para manutenção) e Operação Especial (despesas que não geram produto, como pagamento de dívidas).
+    plain_language: É o que o governo faz na prática com o dinheiro público. Pode ser um projeto (construir uma escola), uma atividade (manter a escola funcionando) ou uma operação especial (pagar uma dívida antiga da educação).
     notes:
       - |
         A coluna `identificador_tipo_acao_cod` pode ser utilizada para segregação das ações percententes aos: 
@@ -123,6 +125,7 @@ fields:
         - __Orçamento fiscal__ (1, 2, 4, 7, 9)
         - __Orçamento de investimento das empresas controladas__ (3, 6, 8)
         - __Ações não orçamentárias__ (5)
+  
   - name: Tipo de Ação
     target: identificador_tipo_acao_desc
     type: string
@@ -154,6 +157,8 @@ fields:
   - name: Projeto Estratégico
     target: projeto_estrategico
     type: string
+    description: São os projetos considerados prioritários para o governo e estão relacionados com os objetivos estratégicos e diretrizes estratégicas do plano de longo prazo do Governo (PMDI 2019-2030).
+    plain_language: Agrupamento das políticas públicas consideradas prioritárias pelo governo, e que recebem um acompanhamento mais intensivo.
   - name: Exclusão Lógica da Ação
     target: is_deleted_acao
     type: boolean
@@ -181,6 +186,8 @@ fields:
   - name: Finalidade da Ação
     target: acao_finalidade
     type: string
+    description: Expressa o propósito da ação, o resultado que se pretende alcançar com a entrega do seu produto (bem ou serviço), devendo ser descrita de forma clara, concisa e iniciada por um verbo no infinitivo.
+    plain_language: É o "para quê" da ação. Se a ação é "Construir creches", a finalidade é "Ampliar o acesso à educação infantil". Explica o benefício esperado para a sociedade.
   - name: Descrição da Ação
     target: acao_descricao
     type: string
@@ -190,12 +197,16 @@ fields:
   - name: Público-Alvo
     target: publico_alvo_desc
     type: string
+    description: Especifica os setores da sociedade ou da própria administração pública aos quais a ação se destina e que se beneficiam direta e legitimamente com os produtos resultantes dela.
+    plain_language: Refere-se a parcela da sociedade, incluindo os próprios órgãos e entidades do setor público, no qual a política pública será destinada. Informa quem deverá se colher beneficios da realização da política pública.
   - name: Código do Produto
     target: produto_cod
     type: integer
   - name: Produto
     target: produto_desc
     type: string
+    description: Bem ou serviço que resulta da execução de uma ação orçamentária, destinado ao público-alvo. Cada ação deve ter um único produto, que é quantificado pela meta física.1
+    plain_language: É o resultado concreto de uma ação do governo. Se a ação é "construir escolas", o produto é "escola construída". Se a ação é "emitir passaportes", o produto é "passaporte emitido".
   - name: Especificação do Produto
     target: produto_especificacao
     type: string
@@ -208,6 +219,8 @@ fields:
   - name: Previsão Orçamentária 2025
     target: vr_meta_orcamentaria_ano0
     type: number
+    description: Valor orçamentário alocado para a execução de uma ação orçamentária durante a vigência do plano ou em suas revisões anuais. Corresponde à dotação orçamentária da ação.1
+    plain_language: É o valor em dinheiro reservado para realizar as entregas. Se a meta física é "construir 10 escolas", a meta orçamentária é o total de reais que se planeja gastar para construir essas 10 escolas.
   - name: Previsão Orçamentária 2026
     target: vr_meta_orcamentaria_ano1
     type: number
@@ -220,6 +233,8 @@ fields:
   - name: Previsão Física 2025
     target: vr_meta_fisica_ano0
     type: integer
+    description: Quantidade de produto (bem ou serviço) a ser ofertada por uma ação orçamentária durante o exercício financeiro, de forma regionalizada.1
+    plain_language: É o objetivo quantitativo de uma ação. Por exemplo: "construir 10 escolas", "vacinar 1 milhão de crianças" ou "pavimentar 50 km de estradas". Diz "quanto" o governo pretende entregar.
   - name: Previsão Física 2026
     target: vr_meta_fisica_ano1
     type: integer
@@ -237,6 +252,8 @@ fields:
   - name: Setor de Governo
     target: setor_governo
     type: string
+    description: Forma de organização das políticas públicas agregadas por de acordo com os órgãos executores das mesmas.
+    plain_language: Organiza as políticas públicas de acordo com os órgãos que realizam as mesmas. Exemplo:  Fazenda ,  Polícia Militar do Estado de Minas Gerais ,  Assembleia Legislativa )
   - name: Política para mulheres
     target: politica_mulheres
     type: string

--- a/schemas/indicadores_planejamento.yaml
+++ b/schemas/indicadores_planejamento.yaml
@@ -11,6 +11,8 @@ fields:
   - name: Indicador
     target: indicador
     type: string
+    description: Instrumento de mensuração para aferir o desempenho de um programa no alcance de seu objetivo. É expresso como uma taxa, índice ou percentual para avaliar a transformação na realidade.
+    plain_language: É o "termômetro" que mede se uma política pública está funcionando. Se o objetivo é "Reduzir a criminalidade", o indicador pode ser a "Taxa de homicídios".
   - name: Exclusão Lógica do Indicador
     target: is_deleted_indicador
     type: boolean

--- a/schemas/localizadores_todos_planejamento.yaml
+++ b/schemas/localizadores_todos_planejamento.yaml
@@ -67,6 +67,8 @@ fields:
   - name: Região Geográfica Intermediária
     target: regiao_geografica_desc
     type: string
+    description: Recorte territorial definido pelo IBGE em 2017, que agrupa municípios em torno de um polo urbano de maior complexidade, para fins de planejamento e gestão de políticas públicas.
+    plain_language: Uma nova forma de dividir o Brasil em regiões, agrupando cidades vizinhas que têm uma cidade maior como referência principal para serviços complexos, como universidades e hospitais especializados.
   - name: Código do Município IBGE
     target: municipio_ibge_cod
     type: integer

--- a/schemas/programas_planejamento.yaml
+++ b/schemas/programas_planejamento.yaml
@@ -5,6 +5,8 @@ fields:
   - name: Nome do Programa
     target: programa_desc
     type: string
+    description: Instrumento de organização da ação governamental que articula um conjunto de ações (projetos, atividades, operações especiais) para alcançar um objetivo comum, visando à solução de um problema ou ao atendimento de uma demanda da sociedade.1
+    plain_language: Representam as politicas públicas que foram planejadas e que serão executadas com os recursos recebidos pelo Estado. Tem por objetivo atender as demandas da sociedade e/ou enfrentar problemas identificados na realidade de quem vive no Estado. Os programas, são desdobrados em ações orçamentárias, que refletem de forma mais direta as ações e projetos que o Estado irá realizar dentro do conjunto da política pública.
   - name: Exclusão Lógica do Programa
     target: is_deleted_programa
     type: boolean
@@ -21,6 +23,8 @@ fields:
   - name: Área Temática
     target: area_tematica_desc
     type: string
+    description: Forma de organização da ação governamental que agrupa programas por temas afins (ex: Saúde, Segurança), independentemente do órgão executor. Divide-se em Finalísticas (que entregam resultados diretos ao cidadão) e de Apoio e Suporte (que dão sustentação à máquina pública).
+    plain_language: Organiza o orçamento por "assuntos" em vez de por "órgãos". A área "Segurança", por exemplo, junta os gastos da polícia, de projetos sociais de prevenção e de outras áreas que contribuem para o mesmo objetivo.
   - name: Código do Objetivo Estratégico
     target: objetivo_estrategico_cod
     type: integer
@@ -51,6 +55,8 @@ fields:
   - name: Objetivo
     target: objetivo
     type: string
+    description: Expressa a transformação que se pretende alcançar na realidade com a implementação de um conjunto de ações, sendo mensurável por meio de indicadores.
+    plain_language: É a grande missão do programa. Define o que se quer mudar ou resolver. Exemplo: "Garantir que 100% da população da cidade tenha acesso à rede de esgoto tratada".
   - name: Justificativa
     target: justificativa
     type: string
@@ -89,6 +95,8 @@ fields:
   - name: Título do Objetivo de Desenvolvimento Sustentável
     target: ods_titulo
     type: string
+    description: Conjunto de 17 objetivos globais da Agenda 2030 da ONU que servem como diretrizes para as políticas públicas. Os programas do Plano Plurianual (PPA/PPAG) devem estar vinculados aos ODS para alinhar o planejamento e o orçamento às metas globais de desenvolvimento.
+    plain_language: Uma "lista de ações" mundial para um futuro melhor (ex: acabar com a fome, proteger o meio ambiente). O governo brasileiro deve mostrar como seus planos e gastos ajudam a cumprir essas tarefas.
   - name: Subtítulo do Objetivo de Desenvolvimento Sustentável
     target: ods_subtitulo
     type: string


### PR DESCRIPTION
@gabrielbdornas 

Conforme orientado, inclui as definições do glossário como description e plain_language nos schemas do repositório.
Como no campo ação já tinha uma description, para padronizar, como ela é mais detalhada, alterei o nome dela para detailed_description e deixei os description para o que for usar para o glossário.